### PR TITLE
Add DNTFeatureSource protocol support

### DIFF
--- a/demo/Features Demo/Features Demo.xcodeproj/project.pbxproj
+++ b/demo/Features Demo/Features Demo.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		6551EF85190A917100A37B47 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6551EF67190A917100A37B47 /* UIKit.framework */; };
 		6551EF8D190A917100A37B47 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 6551EF8B190A917100A37B47 /* InfoPlist.strings */; };
 		6551EF8F190A917100A37B47 /* Features_DemoTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6551EF8E190A917100A37B47 /* Features_DemoTests.m */; };
+		65825AA81956116E0031AFDA /* DNTSyncManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 65825AA71956116E0031AFDA /* DNTSyncManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,8 @@
 		6551EF8A190A917100A37B47 /* Features DemoTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Features DemoTests-Info.plist"; sourceTree = "<group>"; };
 		6551EF8C190A917100A37B47 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6551EF8E190A917100A37B47 /* Features_DemoTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Features_DemoTests.m; sourceTree = "<group>"; };
+		65825AA61956116E0031AFDA /* DNTSyncManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DNTSyncManager.h; sourceTree = "<group>"; };
+		65825AA71956116E0031AFDA /* DNTSyncManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DNTSyncManager.m; sourceTree = "<group>"; };
 		9F5DE063E3B5476089976D39 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA8699D700B74A0E86C95930 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -120,10 +123,12 @@
 			children = (
 				6551EF72190A917100A37B47 /* DNTAppDelegate.h */,
 				6551EF73190A917100A37B47 /* DNTAppDelegate.m */,
-				6551EF75190A917100A37B47 /* Main.storyboard */,
 				6551EF78190A917100A37B47 /* DNTRootViewController.h */,
 				6551EF79190A917100A37B47 /* DNTRootViewController.m */,
+				65825AA61956116E0031AFDA /* DNTSyncManager.h */,
+				65825AA71956116E0031AFDA /* DNTSyncManager.m */,
 				6551EF7B190A917100A37B47 /* Images.xcassets */,
+				6551EF75190A917100A37B47 /* Main.storyboard */,
 				6551EF6A190A917100A37B47 /* Supporting Files */,
 			);
 			path = "Features Demo";
@@ -292,6 +297,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6551EF70190A917100A37B47 /* main.m in Sources */,
+				65825AA81956116E0031AFDA /* DNTSyncManager.m in Sources */,
 				6551EF7A190A917100A37B47 /* DNTRootViewController.m in Sources */,
 				6551EF74190A917100A37B47 /* DNTAppDelegate.m in Sources */,
 			);

--- a/demo/Features Demo/Features Demo/DNTRootViewController.m
+++ b/demo/Features Demo/Features Demo/DNTRootViewController.m
@@ -15,67 +15,11 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    // Add some features
-    [[DNTFeature service] settingWithKey:@"feature.bonus" load:^id<DNTSetting>(DNTFeature *feature, YapDatabaseReadWriteTransaction *transaction) {
+    DNTFeature *bonus = [[DNTFeature alloc] initWithKey:@"feature.bonus" title:@"Show bonus content" group:@"Application Features"];
+    bonus.title = @"Show bonus content";
+    bonus.onByDefault = @NO;
 
-        if ( !feature ) {
-            feature = [[DNTFeature alloc] initWithKey:@"feature.bonus" title:@"Show bonus content" group:@"Application Features"];
-        }
-        feature.title = @"Show bonus content";
-        feature.onByDefault = @NO;
-        return feature;
-        
-    } completion:nil];
-
-    [[DNTFeature service] settingWithKey:@"feature.sync" load:^id<DNTSetting>(DNTFeature *feature, YapDatabaseReadWriteTransaction *transaction) {
-
-        if ( !feature ) {
-            feature = [[DNTFeature alloc] initWithKey:@"feature.sync" title:@"New Sync" group:@"In Development"];
-        }
-        feature.title = @"New sync";
-        feature.onByDefault = @NO;
-        feature.debugOptionsAvailable = YES;
-
-        [feature debugSettingWithKey:@"feature.sync.debug.verbose-logging" update:^id<DNTSetting>(DNTToggleSetting *toggle, YapDatabaseReadWriteTransaction *transaction) {
-
-            if ( !toggle ) {
-                toggle = [[DNTToggleSetting alloc] initWithKey:@"feature.sync.debug.verbose-logging" title:@"Verbose Logging" group:nil];
-            }
-            toggle.title = @"Verbose Logging";
-            toggle.onByDefault = @NO;
-            return toggle;
-
-        } transaction:transaction];
-
-        [feature debugSettingWithKey:@"feature.sync.debug.mode" update:^id<DNTSetting>(DNTSelectOptionSetting *select, YapDatabaseReadWriteTransaction *transaction) {
-
-            if ( !select ) {
-                select = [[DNTSelectOptionSetting alloc] initWithKey:@"feature.sync.debug.mode" title:@"Sync Mode" group:nil];
-            }
-            select.title = @"Sync Mode";
-            select.optionKeys = @[ @"standard", @"advanced", @"magic" ];
-            select.optionTitles = @[ @"Standard", @"Advanced", @"Magic" ];
-            select.selectedIndexes = [NSMutableIndexSet indexSetWithIndex:0];
-            select.multipleSelectionAllowed = NO;
-            return select;
-
-        } transaction:transaction];
-
-        [feature debugSettingWithKey:@"feature.sync.debug.clear-cache" update:^id<DNTSetting>(DNTDebugSetting *debug, YapDatabaseReadWriteTransaction *transaction) {
-
-            if ( !debug ) {
-                debug = [[DNTDebugSetting alloc] initWithKey:@"feature.sync.debug.clear-cache" title:@"Clear Cache" group:nil];
-            }
-            debug.title = @"Clear Cache";
-            debug.userInfo[@"special key"] = @"special value";
-            debug.notificationName = @"ClearCacheNotification";
-            return debug;
-
-        } transaction:transaction];
-
-        return feature;
-
-    } completion:nil];
+    [[DNTFeature service] loadDefaultFeatures:@[ bonus ]];
 
     // For demonstration purpose, listen for when settings change.
     [[NSNotificationCenter defaultCenter] addObserverForName:DNTSettingsDidChangeNotification object:nil queue:[NSOperationQueue currentQueue] usingBlock:^(NSNotification *note) {

--- a/demo/Features Demo/Features Demo/DNTSyncManager.h
+++ b/demo/Features Demo/Features Demo/DNTSyncManager.h
@@ -1,0 +1,13 @@
+//
+//  DNTSyncManager.h
+//  Features Demo
+//
+//  Created by Daniel Thorpe on 21/06/2014.
+//  Copyright (c) 2014 Daniel Thorpe. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <DNTFeatures/DNTFeatures.h>
+
+@interface DNTSyncManager : NSObject <DNTFeatureSource>
+@end

--- a/demo/Features Demo/Features Demo/DNTSyncManager.m
+++ b/demo/Features Demo/Features Demo/DNTSyncManager.m
@@ -1,0 +1,72 @@
+//
+//  DNTSyncManager.m
+//  Features Demo
+//
+//  Created by Daniel Thorpe on 21/06/2014.
+//  Copyright (c) 2014 Daniel Thorpe. All rights reserved.
+//
+
+#import "DNTSyncManager.h"
+#import <YapDatabase/YapDatabase.h>
+
+@implementation DNTSyncManager
+
+#pragma mark - DNTFeatureSource
+
++ (NSString *)settingKey {
+    return @"feature.sync";
+}
+
++ (id <DNTSetting>)settingWithTransaction:(YapDatabaseReadWriteTransaction *)transaction collection:(NSString *)collection {
+
+    NSString *key = [self settingKey];
+    DNTFeature *feature = [transaction objectForKey:key inCollection:collection];
+
+    if (!feature) {
+        feature = [[DNTFeature alloc] initWithKey:key title:@"New Sync" group:@"In Development"];
+    }
+    feature.title = @"New sync";
+    feature.onByDefault = @NO;
+    feature.debugOptionsAvailable = YES;
+
+    [feature debugSettingWithKey:@"feature.sync.debug.verbose-logging" update:^id<DNTSetting>(DNTToggleSetting *toggle, YapDatabaseReadWriteTransaction *transaction) {
+
+        if ( !toggle ) {
+            toggle = [[DNTToggleSetting alloc] initWithKey:@"feature.sync.debug.verbose-logging" title:@"Verbose Logging" group:nil];
+        }
+        toggle.title = @"Verbose Logging";
+        toggle.onByDefault = @NO;
+        return toggle;
+
+    } transaction:transaction];
+
+    [feature debugSettingWithKey:@"feature.sync.debug.mode" update:^id<DNTSetting>(DNTSelectOptionSetting *select, YapDatabaseReadWriteTransaction *transaction) {
+
+        if ( !select ) {
+            select = [[DNTSelectOptionSetting alloc] initWithKey:@"feature.sync.debug.mode" title:@"Sync Mode" group:nil];
+        }
+        select.title = @"Sync Mode";
+        select.optionKeys = @[ @"standard", @"advanced", @"magic" ];
+        select.optionTitles = @[ @"Standard", @"Advanced", @"Magic" ];
+        select.selectedIndexes = [NSMutableIndexSet indexSetWithIndex:0];
+        select.multipleSelectionAllowed = NO;
+        return select;
+
+    } transaction:transaction];
+
+    [feature debugSettingWithKey:@"feature.sync.debug.clear-cache" update:^id<DNTSetting>(DNTDebugSetting *debug, YapDatabaseReadWriteTransaction *transaction) {
+
+        if ( !debug ) {
+            debug = [[DNTDebugSetting alloc] initWithKey:@"feature.sync.debug.clear-cache" title:@"Clear Cache" group:nil];
+        }
+        debug.title = @"Clear Cache";
+        debug.userInfo[@"special key"] = @"special value";
+        debug.notificationName = @"ClearCacheNotification";
+        return debug;
+
+    } transaction:transaction];
+
+    return feature;
+}
+
+@end

--- a/demo/Features Demo/Podfile.lock
+++ b/demo/Features Demo/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - CocoaLumberjack/Core (1.6.5.1)
   - CocoaLumberjack/Extensions (1.6.5.1):
     - CocoaLumberjack/Core
-  - DNTFeatures (0.4):
+  - DNTFeatures (0.5):
     - YapDatabase (~> 2)
   - YapDatabase (2.4.2):
     - YapDatabase/standard
@@ -23,7 +23,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   CocoaLumberjack: baf4a09a3bcbdfea3363556a90104e026d3504e2
-  DNTFeatures: 92cf7a714928bc3151b4b767a29c136f3eecaa6a
+  DNTFeatures: 785f7c71c68296665193d6ddc266d2705187c39a
   YapDatabase: 269e2799fe19c7a517521783b909d11873dcb0c8
 
 COCOAPODS: 0.33.1

--- a/sources/DNTDebugSettingsController.m
+++ b/sources/DNTDebugSettingsController.m
@@ -56,12 +56,6 @@
     }
 }
 
-#pragma mark - Storyboards
-
-- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
-    
-}
-
 #pragma mark - DNTDependencyInjectionDestination
 
 + (Protocol *)expectedDependencyContainerInterface {

--- a/sources/DNTFeaturesService.h
+++ b/sources/DNTFeaturesService.h
@@ -14,11 +14,17 @@
 
 - (DNTFeature *)featureWithKey:(id)key;
 
+- (void)loadDefaultFeatures:(NSArray *)extras;
+
 - (void)resetToDefaults;
 
 - (void)updateFeatures:(NSArray *)features completion:(void(^)(void))completion;
 
 @end
+
+@protocol DNTFeatureSource <DNTSettingSource>
+@end
+
 
 @interface DNTFeaturesService : DNTSettingsService <DNTFeaturesService>
 

--- a/sources/DNTFeaturesService.m
+++ b/sources/DNTFeaturesService.m
@@ -19,6 +19,10 @@
     return [self featureWithKey:key database:self.database collection:self.collection];
 }
 
+- (void)loadDefaultFeatures:(NSArray *)extras {
+    [super loadDefaultSettings:extras];
+}
+
 - (void)resetToDefaults {
     [self resetToDefaultsInDatabase:self.database collection:self.collection];
 }
@@ -37,6 +41,10 @@
 
 - (DNTFeature *)featureWithKey:(id)key database:(YapDatabase *)database collection:(NSString *)collection {
     return (DNTFeature *)[self settingWithKey:key database:database collection:collection];
+}
+
+- (void)loadDefaultSettings:(NSArray *)extras database:(YapDatabase *)database collection:(NSString *)collection completion:(DNTVoidCompletionBlock)completion {
+
 }
 
 - (void)resetToDefaultsInDatabase:(YapDatabase *)database collection:(NSString *)collection {

--- a/sources/DNTSettingsService.h
+++ b/sources/DNTSettingsService.h
@@ -26,6 +26,8 @@ typedef id <DNTSetting>(^DNTSettingArrayUpdateBlock)(id <DNTSetting> existing, i
 
 - (id <DNTSetting>)settingWithKey:(id)key;
 
+- (void)loadDefaultSettings:(NSArray *)extras;
+
 - (void)settingWithKey:(id)key load:(DNTSettingUpdateBlock)update completion:(DNTVoidCompletionBlock)completion;
 
 - (void)settingWithKey:(id)key update:(DNTSettingUpdateBlock)update completion:(DNTVoidCompletionBlock)completion;
@@ -36,18 +38,47 @@ typedef id <DNTSetting>(^DNTSettingArrayUpdateBlock)(id <DNTSetting> existing, i
 
 @end
 
+@protocol DNTSettingSource <NSObject>
+
++ (NSString *)settingKey;
+
++ (id <DNTSetting>)settingWithTransaction:(YapDatabaseReadWriteTransaction *)transaction collection:(NSString *)collection;
+
+@end
+
 @interface DNTSettingsService : NSObject <DNTSettingsService>
 
 @property (nonatomic, strong) YapDatabaseConnection *readOnlyConnection;
 @property (nonatomic, strong) YapDatabaseConnection *readWriteConnection;
 
-- (id <DNTSetting>)settingWithKey:(id)key database:(YapDatabase *)database collection:(NSString *)collection;
+- (id <DNTSetting>)settingWithKey:(id)key
+                         database:(YapDatabase *)database
+                       collection:(NSString *)collection;
 
-- (void)settingWithKey:(id)key asynchronously:(BOOL)asynchronously update:(DNTSettingUpdateBlock)update database:(YapDatabase *)database collection:(NSString *)collection completion:(DNTVoidCompletionBlock)completion;
+- (void)loadDefaultSettings:(NSArray *)extras
+                   database:(YapDatabase *)database
+                 collection:(NSString *)collection
+                 completion:(DNTVoidCompletionBlock)completion;
 
-- (void)updateSettings:(NSArray *)settings asynchronously:(BOOL)asynchronously update:(DNTSettingArrayUpdateBlock)update database:(YapDatabase *)database collection:(NSString *)collection completion:(DNTVoidCompletionBlock)completion;
+- (void)settingWithKey:(id)key
+        asynchronously:(BOOL)asynchronously
+                update:(DNTSettingUpdateBlock)update
+              database:(YapDatabase *)database
+            collection:(NSString *)collection
+            completion:(DNTVoidCompletionBlock)completion;
 
-- (void)executeReadWriteTransaction:(void(^)(YapDatabaseReadWriteTransaction *transaction))transaction completion:(void(^)(void))completion asynchronously:(BOOL)asynchronously;
+- (void)updateSettings:(NSArray *)settings
+        asynchronously:(BOOL)asynchronously
+                update:(DNTSettingArrayUpdateBlock)update
+              database:(YapDatabase *)database
+            collection:(NSString *)collection
+            completion:(DNTVoidCompletionBlock)completion;
+
+- (void)executeReadWriteTransaction:(void(^)(YapDatabaseReadWriteTransaction *transaction))transaction
+                         completion:(void(^)(void))completion
+                     asynchronously:(BOOL)asynchronously;
+
+- (NSArray *)defaultSettingsFromSources;
 
 @end
 


### PR DESCRIPTION
Make it easy to define features & debug settings from anywhere in the code base, and have them be loaded synchronously during application launch.

This can be done by adopting a DNTFeatureSource protocol, which will be discovered by the Objective-C runtime to load/update features & settings.
