### PR TITLE
Features DataSource

### DIFF
--- a/FeatureKit.xcodeproj/project.pbxproj
+++ b/FeatureKit.xcodeproj/project.pbxproj
@@ -21,11 +21,13 @@
 		654FB01C1D7E119F002FA74D /* ServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654FB0141D7E119F002FA74D /* ServiceTests.swift */; };
 		654FB01D1D7E119F002FA74D /* StorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654FB0151D7E119F002FA74D /* StorageTests.swift */; };
 		654FB02C1D7E1201002FA74D /* FeatureKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 654FB0231D7E1201002FA74D /* FeatureKitUI.framework */; };
-		654FB03B1D7E125B002FA74D /* FeatureKitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654FB03A1D7E125B002FA74D /* FeatureKitTests.swift */; };
+		654FB03B1D7E125B002FA74D /* FeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654FB03A1D7E125B002FA74D /* FeaturesTests.swift */; };
 		654FB03E1D7E13AD002FA74D /* FeatureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65D182FD1D65094400DB4BF1 /* FeatureKit.framework */; };
 		654FB0401D7E13D4002FA74D /* FeatureKitUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654FB03F1D7E13D4002FA74D /* FeatureKitUITests.swift */; };
 		654FB0411D7E13FA002FA74D /* FeatureKitUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 654FB03C1D7E128B002FA74D /* FeatureKitUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		655CD92F1D7E1A29008D2185 /* FeaturesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655CD92E1D7E1A29008D2185 /* FeaturesDataSource.swift */; };
+		655CD92F1D7E1A29008D2185 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655CD92E1D7E1A29008D2185 /* DataSource.swift */; };
+		658566D11D7E911300399154 /* DataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658566D01D7E911300399154 /* DataSourceTests.swift */; };
+		658566D31D7E922C00399154 /* FeatureKitTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 658566D21D7E922C00399154 /* FeatureKitTestCase.swift */; };
 		65D183071D65094400DB4BF1 /* FeatureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65D182FD1D65094400DB4BF1 /* FeatureKit.framework */; };
 		65D183181D6509D000DB4BF1 /* FeatureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65D183161D6509D000DB4BF1 /* FeatureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -63,11 +65,13 @@
 		654FB0151D7E119F002FA74D /* StorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StorageTests.swift; sourceTree = "<group>"; };
 		654FB0231D7E1201002FA74D /* FeatureKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		654FB02B1D7E1201002FA74D /* FeatureKitUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FeatureKitUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		654FB03A1D7E125B002FA74D /* FeatureKitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureKitTests.swift; sourceTree = "<group>"; };
+		654FB03A1D7E125B002FA74D /* FeaturesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeaturesTests.swift; sourceTree = "<group>"; };
 		654FB03C1D7E128B002FA74D /* FeatureKitUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FeatureKitUI.h; path = "Supporting Files/FeatureKitUI.h"; sourceTree = "<group>"; };
 		654FB03D1D7E12B9002FA74D /* FeatureKitUI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FeatureKitUI.xcconfig; path = "Supporting Files/FeatureKitUI.xcconfig"; sourceTree = "<group>"; };
 		654FB03F1D7E13D4002FA74D /* FeatureKitUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeatureKitUITests.swift; path = Tests/FeatureKitUITests/FeatureKitUITests.swift; sourceTree = SOURCE_ROOT; };
-		655CD92E1D7E1A29008D2185 /* FeaturesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeaturesDataSource.swift; sourceTree = "<group>"; };
+		655CD92E1D7E1A29008D2185 /* DataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		658566D01D7E911300399154 /* DataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSourceTests.swift; sourceTree = "<group>"; };
+		658566D21D7E922C00399154 /* FeatureKitTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureKitTestCase.swift; sourceTree = "<group>"; };
 		65D182FD1D65094400DB4BF1 /* FeatureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65D183061D65094400DB4BF1 /* FeatureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FeatureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		65D183161D6509D000DB4BF1 /* FeatureKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeatureKit.h; path = "Supporting Files/FeatureKit.h"; sourceTree = "<group>"; };
@@ -116,7 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				654FAFFF1D7E1170002FA74D /* Feature.swift */,
-				655CD92E1D7E1A29008D2185 /* FeaturesDataSource.swift */,
+				655CD92E1D7E1A29008D2185 /* DataSource.swift */,
 				654FB0001D7E1170002FA74D /* JSON.swift */,
 				654FB0011D7E1170002FA74D /* Mapper.swift */,
 				654FB0021D7E1170002FA74D /* RemoteConfiguration.swift */,
@@ -133,7 +137,9 @@
 			children = (
 				654FB00E1D7E119F002FA74D /* Features.json */,
 				654FB00F1D7E119F002FA74D /* FeaturesList.json */,
-				654FB03A1D7E125B002FA74D /* FeatureKitTests.swift */,
+				658566D01D7E911300399154 /* DataSourceTests.swift */,
+				658566D21D7E922C00399154 /* FeatureKitTestCase.swift */,
+				654FB03A1D7E125B002FA74D /* FeaturesTests.swift */,
 				654FB0121D7E119F002FA74D /* JSONTests.swift */,
 				654FB0131D7E119F002FA74D /* MapperTests.swift */,
 				654FB0141D7E119F002FA74D /* ServiceTests.swift */,
@@ -436,7 +442,7 @@
 				654FB00A1D7E1170002FA74D /* Service.swift in Sources */,
 				654FB0081D7E1170002FA74D /* Mapper.swift in Sources */,
 				654FB0071D7E1170002FA74D /* JSON.swift in Sources */,
-				655CD92F1D7E1A29008D2185 /* FeaturesDataSource.swift in Sources */,
+				655CD92F1D7E1A29008D2185 /* DataSource.swift in Sources */,
 				654FB00C1D7E1170002FA74D /* UserDefaults.swift in Sources */,
 				654FB00B1D7E1170002FA74D /* Storage.swift in Sources */,
 			);
@@ -446,9 +452,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				658566D11D7E911300399154 /* DataSourceTests.swift in Sources */,
 				654FB01C1D7E119F002FA74D /* ServiceTests.swift in Sources */,
 				654FB01A1D7E119F002FA74D /* JSONTests.swift in Sources */,
-				654FB03B1D7E125B002FA74D /* FeatureKitTests.swift in Sources */,
+				658566D31D7E922C00399154 /* FeatureKitTestCase.swift in Sources */,
+				654FB03B1D7E125B002FA74D /* FeaturesTests.swift in Sources */,
 				654FB01B1D7E119F002FA74D /* MapperTests.swift in Sources */,
 				654FB01D1D7E119F002FA74D /* StorageTests.swift in Sources */,
 			);

--- a/FeatureKit.xcodeproj/project.pbxproj
+++ b/FeatureKit.xcodeproj/project.pbxproj
@@ -25,7 +25,7 @@
 		654FB03E1D7E13AD002FA74D /* FeatureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65D182FD1D65094400DB4BF1 /* FeatureKit.framework */; };
 		654FB0401D7E13D4002FA74D /* FeatureKitUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654FB03F1D7E13D4002FA74D /* FeatureKitUITests.swift */; };
 		654FB0411D7E13FA002FA74D /* FeatureKitUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 654FB03C1D7E128B002FA74D /* FeatureKitUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		655CD92D1D7E15C9008D2185 /* TableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655CD92C1D7E15C9008D2185 /* TableViewDataSource.swift */; };
+		655CD92F1D7E1A29008D2185 /* FeaturesDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655CD92E1D7E1A29008D2185 /* FeaturesDataSource.swift */; };
 		65D183071D65094400DB4BF1 /* FeatureKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 65D182FD1D65094400DB4BF1 /* FeatureKit.framework */; };
 		65D183181D6509D000DB4BF1 /* FeatureKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 65D183161D6509D000DB4BF1 /* FeatureKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -67,7 +67,7 @@
 		654FB03C1D7E128B002FA74D /* FeatureKitUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FeatureKitUI.h; path = "Supporting Files/FeatureKitUI.h"; sourceTree = "<group>"; };
 		654FB03D1D7E12B9002FA74D /* FeatureKitUI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = FeatureKitUI.xcconfig; path = "Supporting Files/FeatureKitUI.xcconfig"; sourceTree = "<group>"; };
 		654FB03F1D7E13D4002FA74D /* FeatureKitUITests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FeatureKitUITests.swift; path = Tests/FeatureKitUITests/FeatureKitUITests.swift; sourceTree = SOURCE_ROOT; };
-		655CD92C1D7E15C9008D2185 /* TableViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TableViewDataSource.swift; path = Sources/FeatureKitUI/TableViewDataSource.swift; sourceTree = SOURCE_ROOT; };
+		655CD92E1D7E1A29008D2185 /* FeaturesDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeaturesDataSource.swift; sourceTree = "<group>"; };
 		65D182FD1D65094400DB4BF1 /* FeatureKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeatureKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		65D183061D65094400DB4BF1 /* FeatureKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FeatureKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		65D183161D6509D000DB4BF1 /* FeatureKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FeatureKit.h; path = "Supporting Files/FeatureKit.h"; sourceTree = "<group>"; };
@@ -116,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				654FAFFF1D7E1170002FA74D /* Feature.swift */,
+				655CD92E1D7E1A29008D2185 /* FeaturesDataSource.swift */,
 				654FB0001D7E1170002FA74D /* JSON.swift */,
 				654FB0011D7E1170002FA74D /* Mapper.swift */,
 				654FB0021D7E1170002FA74D /* RemoteConfiguration.swift */,
@@ -145,7 +146,6 @@
 		654FB0241D7E1201002FA74D /* FeatureKitUI */ = {
 			isa = PBXGroup;
 			children = (
-				655CD92C1D7E15C9008D2185 /* TableViewDataSource.swift */,
 			);
 			path = FeatureKitUI;
 			sourceTree = "<group>";
@@ -416,7 +416,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				655CD92D1D7E15C9008D2185 /* TableViewDataSource.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -437,6 +436,7 @@
 				654FB00A1D7E1170002FA74D /* Service.swift in Sources */,
 				654FB0081D7E1170002FA74D /* Mapper.swift in Sources */,
 				654FB0071D7E1170002FA74D /* JSON.swift in Sources */,
+				655CD92F1D7E1A29008D2185 /* FeaturesDataSource.swift in Sources */,
 				654FB00C1D7E1170002FA74D /* UserDefaults.swift in Sources */,
 				654FB00B1D7E1170002FA74D /* Storage.swift in Sources */,
 			);

--- a/Sources/FeatureKit/Feature.swift
+++ b/Sources/FeatureKit/Feature.swift
@@ -29,6 +29,15 @@ extension RawRepresentable where RawValue == String {
     }
 }
 
+// MARK: - FeatureIdentifier
+
+/// Protocol which a Feature Identifier must conform to
+public protocol FeatureIdentifier: Hashable, StringRepresentable { }
+
+public func < <ID: FeatureIdentifier where ID: RawRepresentable, ID.RawValue == String> (lhs: ID, rhs: ID) -> Bool {
+    return lhs.rawValue < rhs.rawValue
+}
+
 extension String: FeatureIdentifier {
 
     /// - returns: a string representation of self
@@ -39,11 +48,6 @@ extension String: FeatureIdentifier {
         self = string
     }
 }
-
-// MARK: - FeatureIdentifier
-
-/// Protocol which a Feature Identifier must conform to
-public protocol FeatureIdentifier: Hashable, StringRepresentable { }
 
 // MARK: - FeatureProtocol
 
@@ -92,6 +96,14 @@ public extension MutableFeatureProtocol {
 
     public var toggled: Bool {
         return defaultAvailability != available
+    }
+}
+
+public func < <Feature: FeatureProtocol where Feature.Identifier: Comparable>(lhs: Feature, rhs: Feature) -> Bool {
+    switch (lhs.parent, rhs.parent) {
+    case (.None, .Some(_)): return true
+    case (.Some(_), .None): return false
+    default: return lhs.id < rhs.id
     }
 }
 

--- a/Sources/FeatureKit/Feature.swift
+++ b/Sources/FeatureKit/Feature.swift
@@ -4,7 +4,6 @@
 //  Copyright © 2016 FeatureKit. All rights reserved.
 //
 
-import Foundation
 import ValueCoding
 
 // MARK: - Support Interfaces
@@ -96,6 +95,12 @@ public extension MutableFeatureProtocol {
     }
 }
 
+extension CollectionType where Generator.Element: FeatureProtocol {
+
+    public var asFeaturesByIdentifier: [Generator.Element.Identifier: Generator.Element] {
+        return reduce([:]) { var acc = $0; acc[$1.id] = $1; return acc }
+    }
+}
 
 // MARK: - Feature<Identifier>
 

--- a/Sources/FeatureKit/FeaturesDataSource.swift
+++ b/Sources/FeatureKit/FeaturesDataSource.swift
@@ -1,0 +1,63 @@
+//
+//  FeatureKit
+//
+//  Copyright © 2016 FeatureKit. All rights reserved.
+//
+
+public protocol FeaturesDataSourceProtocol {
+
+    associatedtype Feature: FeatureProtocol
+
+    var numberOfGroups: Int { get }
+
+    func numberOfFeaturesInGroupAtIndex(index: Int) -> Int
+
+    func featureAtIndex(_: Int, inGroup: Int) -> Feature
+}
+
+public class FeaturesDataSource<Service: FeatureServiceProtocol> {
+    public typealias Feature = Service.Feature
+
+    private var service: Service
+
+    public init(service: Service) {
+        self.service = service
+    }
+
+}
+
+
+internal extension FeatureServiceProtocol {
+
+    var groups: Dictionary<Feature.Identifier,Feature> {
+        return features.values.filter({ $0.parent == nil }).asFeaturesByIdentifier
+    }
+
+    func group(atIndex index: Int) -> [Feature] {
+        let _groups = groups
+        let parent = (Array<Feature.Identifier>)(_groups.keys)[index]
+        guard let feature = _groups[parent] else { return [] }
+        var result = [feature]
+        result.appendContentsOf(features(withParentIdentifier: parent))
+        return result
+    }
+
+    func features(withParentIdentifier parent: Feature.Identifier) -> [Feature] {
+        return features.values.filter { $0.parent == parent }
+    }
+}
+
+extension FeaturesDataSource: FeaturesDataSourceProtocol {
+
+    public var numberOfGroups: Int {
+        return service.groups.count
+    }
+
+    public func numberOfFeaturesInGroupAtIndex(index: Int) -> Int {
+        return service.group(atIndex: index).count
+    }
+
+    public func featureAtIndex(index: Int, inGroup groupIndex: Int) -> Feature {
+        return service.group(atIndex: groupIndex)[index]
+    }
+}

--- a/Sources/FeatureKit/Service.swift
+++ b/Sources/FeatureKit/Service.swift
@@ -15,6 +15,11 @@ public protocol FeatureServiceProtocol {
     /// The type of the Feature that the Service provides
     associatedtype Feature: FeatureProtocol
 
+    /// Access all features
+    ///
+    /// - returns: a Dictionary of Features keyed by their id
+    var features: Dictionary<Feature.Identifier, Feature> { get }
+
     /// Access a feature by its identifier
     ///
     /// - parameter id: a Feature.Identifier
@@ -68,31 +73,27 @@ public extension MutableFeatureServiceProtocol {
 public final class FeatureService<Feature: FeatureProtocol> {
     public typealias Storage = AnyStorage<Feature.Identifier, Feature>
 
-    private var _features: [Feature.Identifier: Feature] // swiftlint:disable:this variable_name
     private var storage: Storage? = nil
     private var download: Download<[Feature]>? = nil
-
-    public var features: [Feature] {
-        return Array(_features.values)
-    }
+    public private(set) var features: [Feature.Identifier: Feature]
 
     public required init(_ features: [Feature.Identifier: Feature] = [:]) {
-        _features = features
+        self.features = features
     }
 }
 
 extension FeatureService: MutableFeatureServiceProtocol {
 
     public func feature(id: Feature.Identifier) -> Feature? {
-        return _features[id]
+        return features[id]
     }
 
     public func set(features features: [Feature.Identifier: Feature]) {
-        _features = features
+        self.features = features
     }
 
     public func set<C: CollectionType where C.Generator.Element == Feature>(features features: C) {
-        _features = features.reduce([:]) { var acc = $0; acc[$1.id] = $1; return acc }
+        self.features = features.asFeaturesByIdentifier
     }
 }
 

--- a/Sources/FeatureKit/Service.swift
+++ b/Sources/FeatureKit/Service.swift
@@ -53,9 +53,9 @@ public protocol MutableFeatureServiceProtocol: FeatureServiceProtocol {
 
     init(_ features: [Feature.Identifier: Feature])
 
-    mutating func set<C: CollectionType where C.Generator.Element == Feature>(features features: C)
+    mutating func set<C: CollectionType where C.Generator.Element == Feature>(features features: C) -> Self
 
-    mutating func set(features features: [Feature.Identifier: Feature])
+    mutating func set(features features: [Feature.Identifier: Feature]) -> Self
 }
 
 public extension MutableFeatureServiceProtocol {
@@ -88,12 +88,13 @@ extension FeatureService: MutableFeatureServiceProtocol {
         return features[id]
     }
 
-    public func set(features features: [Feature.Identifier: Feature]) {
+    public func set(features features: [Feature.Identifier: Feature]) -> FeatureService {
         self.features = features
+        return self
     }
 
-    public func set<C: CollectionType where C.Generator.Element == Feature>(features features: C) {
-        self.features = features.asFeaturesByIdentifier
+    public func set<C: CollectionType where C.Generator.Element == Feature>(features features: C) -> FeatureService {
+        return set(features: features.asFeaturesByIdentifier)
     }
 }
 

--- a/Sources/FeatureKitUI/TableViewDataSource.swift
+++ b/Sources/FeatureKitUI/TableViewDataSource.swift
@@ -1,8 +1,0 @@
-//
-//  FeatureKit
-//
-//  Copyright © 2016 FeatureKit. All rights reserved.
-//
-import Foundation
-import FeatureKit
-

--- a/Tests/FeatureKit/DataSourceTests.swift
+++ b/Tests/FeatureKit/DataSourceTests.swift
@@ -18,19 +18,58 @@ class DataSourceTests: FeatureKitTestCase {
     }
 
     func test__number_of_groups() {
-        XCTAssertEqual(dataSource.numberOfGroups, 3)
+        XCTAssertEqual(dataSource.numberOfSections, 3)
     }
 
     func test__number_of_features_in_groups() {
-        XCTAssertEqual(dataSource.numberOfFeaturesInGroupAtIndex(0), 1) // Bar
-        XCTAssertEqual(dataSource.numberOfFeaturesInGroupAtIndex(1), 2) // Bat, Baz
-        XCTAssertEqual(dataSource.numberOfFeaturesInGroupAtIndex(2), 1) // Foo
+        XCTAssertEqual(dataSource.numberOfFeatures(inSection: 0), 1) // Bar
+        XCTAssertEqual(dataSource.numberOfFeatures(inSection: 1), 2) // Bat, Baz
+        XCTAssertEqual(dataSource.numberOfFeatures(inSection: 2), 1) // Foo
     }
 
     func test__features_in_group() {
-        XCTAssertEqual(dataSource.featureAtIndex(0, inGroup: 0).id, TestFeatureId.Bar)
-        XCTAssertEqual(dataSource.featureAtIndex(0, inGroup: 1).id, TestFeatureId.Bat)
-        XCTAssertEqual(dataSource.featureAtIndex(1, inGroup: 1).id, TestFeatureId.Baz)
-        XCTAssertEqual(dataSource.featureAtIndex(0, inGroup: 2).id, TestFeatureId.Foo)
+        XCTAssertEqual(dataSource.feature(atIndex: 0, inSection: 0).id, TestFeatureId.Bar)
+        XCTAssertEqual(dataSource.feature(atIndex: 0, inSection: 1).id, TestFeatureId.Bat)
+        XCTAssertEqual(dataSource.feature(atIndex: 1, inSection: 1).id, TestFeatureId.Baz)
+        XCTAssertEqual(dataSource.feature(atIndex: 0, inSection: 2).id, TestFeatureId.Foo)
+    }
+}
+
+class SpeciaEdgeCaseDataSource: FeatureKitTestCase {
+
+    var dataSource: DataSource<TestFeatureService>!
+
+    override func setUp() {
+        super.setUp()
+        setupServiceManually()
+        dataSource = DataSource(service: service)
+    }
+
+    override func createFeatures() -> [TestFeature] {
+        // Special edge case is where there are no parent features
+        return [
+            TestFeature(id: .Foo, title: "foo", defaultAvailability: true, currentAvailability: true),
+            TestFeature(id: .Bar, title: "bar", defaultAvailability: true, currentAvailability: false),
+            TestFeature(id: .Bat, title: "bat", defaultAvailability: false, currentAvailability: true),
+            TestFeature(id: .Baz, title: "baz", defaultAvailability: false, currentAvailability: false)
+        ]
+    }
+
+    func test__number_of_groups() {
+        // When there are no parents, we want a single group
+        XCTAssertEqual(dataSource.numberOfSections, 1)
+    }
+
+    func test__number_of_features_in_groups() {
+        // When there are no parents, we want all features in one group
+        XCTAssertEqual(dataSource.numberOfFeatures(inSection: 0), 4)
+    }
+
+    func test__features_in_group() {
+        // Features are always sorted in order
+        XCTAssertEqual(dataSource.feature(atIndex: 0, inSection: 0).id, TestFeatureId.Bar)
+        XCTAssertEqual(dataSource.feature(atIndex: 1, inSection: 0).id, TestFeatureId.Bat)
+        XCTAssertEqual(dataSource.feature(atIndex: 2, inSection: 0).id, TestFeatureId.Baz)
+        XCTAssertEqual(dataSource.feature(atIndex: 3, inSection: 0).id, TestFeatureId.Foo)
     }
 }

--- a/Tests/FeatureKit/DataSourceTests.swift
+++ b/Tests/FeatureKit/DataSourceTests.swift
@@ -1,0 +1,36 @@
+//
+//  FeatureKit
+//
+//  Copyright © 2016 FeatureKit. All rights reserved.
+//
+
+import XCTest
+@testable import FeatureKit
+
+class DataSourceTests: FeatureKitTestCase {
+
+    var dataSource: DataSource<TestFeatureService>!
+
+    override func setUp() {
+        super.setUp()
+        setupServiceManually()
+        dataSource = DataSource(service: service)
+    }
+
+    func test__number_of_groups() {
+        XCTAssertEqual(dataSource.numberOfGroups, 3)
+    }
+
+    func test__number_of_features_in_groups() {
+        XCTAssertEqual(dataSource.numberOfFeaturesInGroupAtIndex(0), 1) // Bar
+        XCTAssertEqual(dataSource.numberOfFeaturesInGroupAtIndex(1), 2) // Bat, Baz
+        XCTAssertEqual(dataSource.numberOfFeaturesInGroupAtIndex(2), 1) // Foo
+    }
+
+    func test__features_in_group() {
+        XCTAssertEqual(dataSource.featureAtIndex(0, inGroup: 0).id, TestFeatureId.Bar)
+        XCTAssertEqual(dataSource.featureAtIndex(0, inGroup: 1).id, TestFeatureId.Bat)
+        XCTAssertEqual(dataSource.featureAtIndex(1, inGroup: 1).id, TestFeatureId.Baz)
+        XCTAssertEqual(dataSource.featureAtIndex(0, inGroup: 2).id, TestFeatureId.Foo)
+    }
+}

--- a/Tests/FeatureKit/FeatureKitTestCase.swift
+++ b/Tests/FeatureKit/FeatureKitTestCase.swift
@@ -1,0 +1,67 @@
+//
+//  FeatureKit
+//
+//  Copyright © 2016 FeatureKit. All rights reserved.
+//
+
+import XCTest
+import ValueCoding
+@testable import FeatureKit
+
+enum TestFeatureId: String, FeatureIdentifier, Comparable, ValueCoding {
+    typealias Coder = RawRepresentableStringCoder<TestFeatureId>
+
+    case Foo = "Foo"
+    case Bar = "Bar"
+    case Bat = "Bat"
+    case Baz = "Baz"
+    case Fat = "Fat"
+    case Hat = "Hat"
+}
+
+enum TestFeaturesError<ID: FeatureIdentifier>: ErrorType {
+    case FeatureNotDefinied(ID)
+}
+
+typealias TestFeature = Feature<TestFeatureId>
+typealias TestFeatureService = FeatureService<TestFeature>
+
+class FeatureKitTestCase: XCTestCase {
+
+    var service: TestFeatureService!
+
+    override func tearDown() {
+        service = nil
+        super.tearDown()
+    }
+
+    func createFeatures() -> [TestFeature] {
+        return [
+            TestFeature(id: .Foo, title: "foo", defaultAvailability: true, currentAvailability: true),
+            TestFeature(id: .Bar, title: "bar", defaultAvailability: true, currentAvailability: false),
+            TestFeature(id: .Bat, title: "bat", defaultAvailability: false, currentAvailability: true),
+            TestFeature(id: .Baz, parent: .Bat, title: "baz", defaultAvailability: false, currentAvailability: false)
+        ]
+    }
+
+    func setupServiceManually() {
+        service = TestFeatureService().set(features: createFeatures())
+    }
+
+    func setupServiceFromJSON() {
+        service = TestFeatureService()
+
+        let mapper = TestFeature.mapper(searchForKey: "features")
+
+        do {
+            guard let path = NSBundle(forClass: self.dynamicType).pathForResource("Features", ofType: "json") else { return }
+
+            let data = try NSData(contentsOfFile: path, options: [])
+
+            let features = try mapper.map(data)
+
+            service.set(features: features)
+        }
+        catch { }
+    }
+}

--- a/Tests/FeatureKit/FeaturesTests.swift
+++ b/Tests/FeatureKit/FeaturesTests.swift
@@ -8,36 +8,11 @@ import XCTest
 import ValueCoding
 @testable import FeatureKit
 
-enum TestFeatureId: String, FeatureIdentifier, ValueCoding {
-    typealias Coder = RawRepresentableStringCoder<TestFeatureId>
-
-    case Foo = "Foo"
-    case Bar = "Bar"
-    case Bat = "Bat"
-    case Baz = "Baz"
-    case Fat = "Fat"
-    case Hat = "Hat"
-}
-
-enum TestFeaturesError<ID: FeatureIdentifier>: ErrorType {
-    case FeatureNotDefinied(ID)
-}
-
-typealias TestFeature = Feature<TestFeatureId>
-typealias TestFeatureService = FeatureService<TestFeature>
-
-class TestFeatures: XCTestCase {
-
-    var service: TestFeatureService!
+class FeaturesTests: FeatureKitTestCase {
 
     override func setUp() {
         super.setUp()
-        service = TestFeatureService([
-            .Foo: TestFeature(id: .Foo, title: "foo", defaultAvailability: true, currentAvailability: true),
-            .Bar: TestFeature(id: .Bar, title: "bar", defaultAvailability: true, currentAvailability: false),
-            .Bat: TestFeature(id: .Bat, title: "bat", defaultAvailability: false, currentAvailability: true),
-            .Baz: TestFeature(id: .Baz, title: "baz", defaultAvailability: false, currentAvailability: false)
-        ])
+        setupServiceManually()
     }
 
     func test__get_feature_with_exits() {

--- a/Tests/FeatureKit/ServiceTests.swift
+++ b/Tests/FeatureKit/ServiceTests.swift
@@ -8,12 +8,11 @@ import XCTest
 import ValueCoding
 @testable import FeatureKit
 
-class ServiceTests: XCTestCase {
+class ServiceTests: FeatureKitTestCase {
 
     var testableUserDefaults: TestableUserDefaults!
     var adaptor: UserDefaultsStorage<TestFeature.Identifier, TestFeature.Coder>!
     var storage: AnyValueStorage<TestFeature.Identifier, TestFeature>!
-    var service: TestFeatureService!
 
     override func setUp() {
         super.setUp()
@@ -27,17 +26,7 @@ class ServiceTests: XCTestCase {
     override func tearDown() {
         testableUserDefaults = nil
         adaptor = nil
-        service = nil
         super.tearDown()
-    }
-
-    func createFeatures() -> [TestFeature] {
-        return [
-            TestFeature(id: .Foo, title: "foo", defaultAvailability: true, currentAvailability: true),
-            TestFeature(id: .Bar, title: "bar", defaultAvailability: true, currentAvailability: false),
-            TestFeature(id: .Bat, title: "bat", defaultAvailability: false, currentAvailability: true),
-            TestFeature(id: .Baz, title: "baz", defaultAvailability: false, currentAvailability: false)
-        ]
     }
 
     func test__initialize_with_storage() {


### PR DESCRIPTION
To be able to present a UI we are going to require a datasource. The first step is to present a minimal _features data source_ which will allow for us to expose things like

- [x] Number of sections. 
    i.e. a group would be all the features under the same parent. There is a one-to-one child-parent relationship, so this is fairly simple. If there are no parent-child relationships among the features, then all features appear under a single section.

- [x] Number of features in the section at index.
    i.e. if we have 10 groups, how many items (including the top level parent feature) are in the group at index 0 -> 9

- [x] Feature at index in the section at index.
    i.e. return the feature which is index 1 in group at index 3.

These APIs will form the basis of a future `UITableViewDataSource` inside the FeatureKitUI framework.